### PR TITLE
Error when importing schema to zfc-user table

### DIFF
--- a/data/schema.sql
+++ b/data/schema.sql
@@ -1,7 +1,7 @@
 CREATE TABLE user_remember_me (
   sid VARCHAR(16) NOT NULL,
   token VARCHAR(16) NOT NULL,
-  user_id INTEGER(11) NOT NULL,
+  user_id INTEGER(11) unsigned NOT NULL,
   UNIQUE KEY sid (sid,token,user_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 


### PR DESCRIPTION
When importing existing schema and creating foreign key user will receive errno 150 due to different column definition (user_id).
In zfc-user table user_id is defined as unsigned, to fix this added unsigned to goalio schema too.
