### PR TITLE
Add cookie domain as module option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ The following options are available:
   `GoalioRememberMe\Entity\RememberMe`.
 - **cookie_expire** - Integer value in seconds when the login cookie should expire. 
   Default is `2592000` (30 days).
+- **cookie_domain** - String value for the domain this cookie should be set for. 
+  Default is null.
   
 Security
 --------

--- a/config/goaliorememberme.global.php.dist
+++ b/config/goaliorememberme.global.php.dist
@@ -24,6 +24,14 @@ $settings = array(
      * Accepted values: the number of seconds the user should be remembered
      */
     //'cookie_expire' => 2592000,
+    
+    /**
+     * Remember me cookie domain
+     *
+     * Default value: null (current domain)
+     * Accepted values: a string containing the domain (example.com), subdomains (sub.example.com) or the all subdomains qualifier (.example.com)
+     */
+    //'cookie_domain' => null,
 
     /**
      * End of GoalioRememberMe configuration

--- a/src/GoalioRememberMe/Options/ModuleOptions.php
+++ b/src/GoalioRememberMe/Options/ModuleOptions.php
@@ -21,6 +21,11 @@ class ModuleOptions extends AbstractOptions implements
     /**
      * @var string
      */
+    protected $cookieDomain = null;
+    
+    /**
+     * @var string
+     */
     protected $rememberMeEntityClass = 'GoalioRememberMe\Entity\RememberMe';
 
     public function setCookieExpire($seconds)
@@ -41,5 +46,14 @@ class ModuleOptions extends AbstractOptions implements
 
 	public function getRememberMeEntityClass() {
         return $this->rememberMeEntityClass;
+    }
+    
+    public function getCookieDomain() {
+        return $this->cookieDomain;
+    }
+    
+    public function setCookieDomain($cookieDomain) {
+        $this->cookieDomain = $cookieDomain;
+        return $this;
     }
 }

--- a/src/GoalioRememberMe/Options/RememberMeOptionsInterface.php
+++ b/src/GoalioRememberMe/Options/RememberMeOptionsInterface.php
@@ -13,4 +13,9 @@ interface RememberMeOptionsInterface
      * @return int
      */
     public function getCookieExpire();
+    
+    /**
+     * @return string
+     */
+    public function getCookieDomain();
 }

--- a/src/GoalioRememberMe/Service/RememberMe.php
+++ b/src/GoalioRememberMe/Service/RememberMe.php
@@ -78,8 +78,9 @@ class RememberMe extends EventProvider implements ServiceManagerAwareInterface
     public function setCookie($entity)
     {
         $cookieLength = $this->getOptions()->getCookieExpire();
+        $cookieDomain = $this->getOptions()->getCookieDomain();
         $cookieValue = $entity->getUserId() . "\n" . $entity->getSid() . "\n" . $entity->getToken();
-        return setcookie("remember_me", $cookieValue, time() + $cookieLength, '/', null, null, true);
+        return setcookie("remember_me", $cookieValue, time() + $cookieLength, '/', $cookieDomain, null, true);
     }
 
     /**


### PR DESCRIPTION
Currently it is impossible to set the cookie domain. This pull requests introduces this feature as a module configuration item.
