### PR TITLE
Add PostgreSQL Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "goalio/goalio-rememberme",
+    "name": "prevostc/goalio-rememberme",
     "description": "Adding Remember Me functionalitiy to ZfcUser",
     "type": "library",
     "license": "BSD-3-Clause",
@@ -7,14 +7,7 @@
         "zf2",
         "zfcuser"
     ],
-    "homepage": "https://github.com/goalio/GoalioRememberMe",
-    "authors": [
-        {
-            "name": "Philipp Dobrigkeit",
-            "email": "p.dobrigkeit@goalio.de",
-            "homepage": "http://www.goalio.de"
-        }
-    ],
+    "homepage": "https://github.com/prevostc/GoalioRememberMe",
     "require": {
         "zf-commons/zfc-user": "1.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "prevostc/goalio-rememberme",
+    "name": "goalio/goalio-rememberme",
     "description": "Adding Remember Me functionalitiy to ZfcUser",
     "type": "library",
     "license": "BSD-3-Clause",
@@ -7,7 +7,14 @@
         "zf2",
         "zfcuser"
     ],
-    "homepage": "https://github.com/prevostc/GoalioRememberMe",
+    "homepage": "https://github.com/goalio/GoalioRememberMe",
+    "authors": [
+        {
+            "name": "Philipp Dobrigkeit",
+            "email": "p.dobrigkeit@goalio.de",
+            "homepage": "http://www.goalio.de"
+        }
+    ],
     "require": {
         "zf-commons/zfc-user": "1.*"
     },

--- a/src/GoalioRememberMe/Mapper/RememberMe.php
+++ b/src/GoalioRememberMe/Mapper/RememberMe.php
@@ -2,7 +2,7 @@
 
 namespace GoalioRememberMe\Mapper;
 
-use ZfcBase\Mapper\AbstractDbMapper
+use ZfcBase\Mapper\AbstractDbMapper;
 use Zend\Db\Sql\Where;
 
 class RememberMe extends AbstractDbMapper
@@ -63,8 +63,8 @@ class RememberMe extends AbstractDbMapper
     public function removeSerie($userId, $serieId)
     {
         $where = new Where();
-        $where->equalTo('user_id', userId);
-        $where->equalTo('sid', serieId);
+        $where->equalTo('user_id', $userId);
+        $where->equalTo('sid', $serieId);
         return parent::delete($where, $this->tableName);
     }
 }

--- a/src/GoalioRememberMe/Mapper/RememberMe.php
+++ b/src/GoalioRememberMe/Mapper/RememberMe.php
@@ -2,7 +2,8 @@
 
 namespace GoalioRememberMe\Mapper;
 
-use ZfcBase\Mapper\AbstractDbMapper;
+use ZfcBase\Mapper\AbstractDbMapper
+use Zend\Db\Sql\Where;
 
 class RememberMe extends AbstractDbMapper
 {
@@ -30,7 +31,9 @@ class RememberMe extends AbstractDbMapper
 
     public function updateSerie($entity)
     {
-        $where = 'user_id = ' . $entity->getUserId() . ' AND sid = \'' . $entity->getSid() . '\'';
+        $where = new Where();
+        $where->equalTo('user_id', $entity->getUserId());
+        $where->equalTo('sid', $entity->getSid());
         $hydrator = new RememberMeHydrator;
         return parent::update($entity, $where, $this->tableName, $hydrator);
     }
@@ -43,19 +46,25 @@ class RememberMe extends AbstractDbMapper
 
     public function removeAll($userId)
     {
-        $where = 'user_id = ' . $userId;
+        $where = new Where();
+        $where->equalTo('user_id', $userId);
         return parent::delete($where, $this->tableName);
     }
 
     public function remove($entity)
     {
-        $where = 'user_id = ' . $entity->getUserId() . ' AND sid = \'' . $entity->getSid() . '\' AND token = \'' . $entity->getToken() . '\'';
+        $where = new Where();
+        $where->equalTo('user_id', $entity->getUserId());
+        $where->equalTo('sid', $entity->getSid());
+        $where->equalTo('token', $entity->getToken());
         return parent::delete($where, $this->tableName);
     }
 
     public function removeSerie($userId, $serieId)
     {
-        $where = 'user_id = ' . $userId . ' AND sid = \'' . $serieId . '\'';
+        $where = new Where();
+        $where->equalTo('user_id', userId);
+        $where->equalTo('sid', serieId);
         return parent::delete($where, $this->tableName);
     }
 }


### PR DESCRIPTION
PostgreSQL use single quotes as a string escape character and double quotes as metadata escape character.
Using Zend\Db Where object fix the PostgreSQL compatibility issue and provide an extra security bonus against SQL injections (unlikely, but it's for free)